### PR TITLE
🐛 Fix sort for tags

### DIFF
--- a/partials/sidebar.hbs
+++ b/partials/sidebar.hbs
@@ -4,7 +4,7 @@
             {{> sidebar-search}}
             <div class="sidebar-navigation">
                 <ul>
-                {{#get "tags" limit="all" include="count.posts" order="name asc" filter="slug:-faq"}}
+                {{#get "tags" limit="all" include="count.posts" order="description asc" filter="slug:-faq"}}
                 {{#foreach tags}}
                     <li id="{{slug}}"><a href="{{url}}">{{name}}</a>
                         <ul>

--- a/tag.hbs
+++ b/tag.hbs
@@ -7,9 +7,9 @@
             <div class="col-lg-9 topic-archive">
                 {{#tag}}
                 <h1 class="topic-name">{{name}}</h1>
-                <div class="topic-description">
-                    {{description}}
-                </div>
+                <!-- <div class="topic-description">
+                    {{! description}}
+                </div> -->
                 {{/tag}}
                 <div class="post-list-wrap">
                     {{#get "posts" filter="tag:{{tag.slug}}" limit="all" order="published_at asc"}}


### PR DESCRIPTION
Instead of sorting tags by name - sort them by description instead. Additionally disable the viewing of the description when clicking on a tag category

- 🐛 Fix sort for tags
